### PR TITLE
fix: replace dead eth.llamarpc.com L1 RPC with ethereum-rpc.publicnode.com

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -172,7 +172,7 @@ export const networks = [
     testnet: false,
     rpcUrls: {
       default: {
-        http: ['https://eth.llamarpc.com'],
+        http: ['https://ethereum-rpc.publicnode.com'],
       },
     },
   },


### PR DESCRIPTION
eth.llamarpc.com returns HTTP 521 (origin down), breaking all bridge L1 reads: withdrawal status stuck at 'Wait for the published withdraw on L1' and Prove failing with 'Error: null'. Verified ethereum-rpc.publicnode.com serves the L2OutputOracle calls with CORS enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)